### PR TITLE
《简单一点》皮肤

### DIFF
--- a/styles/extensions/lite-shuai/manifest.json
+++ b/styles/extensions/lite-shuai/manifest.json
@@ -1,7 +1,7 @@
 {
-  "name": "jiandan-shuaiqiang",
+  "name": "jiandan-shuaiqiang[Dark Theme]",
   "i18n": {
-    "zh_CN": "简单一点"
+    "zh_CN": "简单一点【暗色主题】"
   },
   "author": "帅强"
 }

--- a/styles/extensions/lite-shuai/manifest.json
+++ b/styles/extensions/lite-shuai/manifest.json
@@ -1,0 +1,7 @@
+{
+  "name": "jiandan-shuaiqiang",
+  "i18n": {
+    "zh_CN": "简单一点"
+  },
+  "author": "帅强"
+}

--- a/styles/extensions/lite-shuai/style.min.css
+++ b/styles/extensions/lite-shuai/style.min.css
@@ -1,0 +1,346 @@
+ /*.physton-prompt .prompt-header .prompt-unfold .icon-svg-unfold:before {
+   
+    更换图标
+    Change icon
+    
+    background-image: url(/physton_prompt/styles?file=extensions/demo/images/test.png);
+    background-size: 100% 100%;
+    content: "";
+    display: inline-block;
+    width: 20px;
+    height: 20px
+}
+
+.physton-prompt .prompt-header .prompt-unfold .icon-svg-unfold svg {
+    /*
+    隐藏原始的图标
+    Hide the original icon
+ 
+ display: none }   */
+ /*
+浅色主题
+Light theme
+*/
+ body.light .physton-prompt .prompt-header {
+   /*
+    更换标题栏背景色
+    Change the background color of the title bar
+    */
+   background: #
+ }
+ /**
+深色主题
+Dark theme
+*/
+body.dark ::-webkit-scrollbar {
+      width: 6px;
+      border-radius: 3px;
+  }
+body.dark ::-webkit-scrollbar-track {
+      background-color:#0d131c;
+      border-radius: 3px;
+  }
+body.dark ::-webkit-scrollbar-thumb {
+      background-color: #506c90;
+      border-radius: 3px;
+  }
+ body.dark .physton-prompt .prompt-header {
+   /*
+    更换标题栏背景色
+    Change the background color of the title bar
+    */
+    margin: 0;
+    border-bottom: 1px dashed #3741518c;
+    color: #9ea7ae;
+	background-color: rgba(31, 41, 55, 0.56);
+	 height: 41px;
+	 padding-left: 8px;
+	 padding-right: 8px;
+	 padding-top: 2px;
+ }
+/*图标颜色*/
+ body.dark .physton-prompt .prompt-header .extend-btn-item .icon-svg-remove svg path,body.dark .physton-prompt .prompt-header .extend-btn-item .icon-svg-copy svg path,body.dark  .physton-prompt .prompt-header .extend-btn-item .icon-svg-english svg path,body.dark  .physton-prompt .prompt-header .extend-btn-item .icon-svg-translate svg path,body.dark .physton-prompt .prompt-header .extend-btn-item .icon-svg-favorite svg path,body.dark .physton-prompt .prompt-header .extend-btn-item .icon-svg-history svg path,body.dark .physton-prompt .prompt-header .extend-btn-item .icon-svg-setting svg path,body.dark .physton-prompt .prompt-header .extend-btn-item .icon-svg-i18n svg path,body.dark .physton-prompt .prompt-header .prompt-unfold .icon-svg-unfold svg path,body.dark .physton-prompt .prompt-header .icon-svg-input svg path {
+   fill: #596572;
+ }
+
+/*图标尺寸*/
+body.dark .physton-prompt .prompt-header .setting-box .icon-svg-api svg,body.dark .physton-prompt .prompt-header .setting-box .icon-svg-theme svg,body.dark .physton-prompt .prompt-header .setting-box .icon-svg-remove-space svg,body.dark .physton-prompt .prompt-header .setting-box .icon-svg-tooltip svg{width: 18px;    height:18px;}
+
+ body.dark .physton-prompt .prompt-header .prompt-header-extend .extend-content .extend-btn-group {
+   display: flex;
+   justify-content: center;
+   align-items: center;
+   color: #fff;
+   background: #0b0f19a6;
+   border: 0;
+   padding: 0;
+   border-radius: 4px;
+ }
+body.dark .physton-prompt .prompt-header .prompt-header-extend .extend-content .extend-btn-group .extend-btn-item:hover {
+   background:#b6c6d3;border-radius: 4px;
+ }
+ body.dark .physton-prompt .prompt-header .prompt-header-extend .extend-content .extend-btn-group .extend-btn-item {
+   cursor: pointer;
+   border-left: 1px solid #161e2a00;
+   height: 26px;
+   width: 30px;
+   display: flex;
+   justify-content: center;
+   align-items: center;
+   position: relative;
+ }
+body.dark .physton-prompt .prompt-header .prompt-header-extend .extend-content .input-tag-append {
+   display: block;
+   position: relative;
+   outline: none !important;
+   height: 30px !important;
+   padding: 6px 8px !important;
+   box-shadow: var(--input-shadow);
+   border: var(--input-border-width) solid #232f41;
+   border-radius: var(--input-radius);
+   background: #0b0f19;
+   margin-left: 5px;
+   padding: var(--input-padding);
+   color: var(--body-text-color);
+   font-weight: var(--input-text-weight);
+   font-size: var(--input-text-size);
+   line-height: var(--line-sm);
+ }
+ body.dark .extend-content input::-webkit-input-placeholder {
+   color: #6b7280;
+ }
+ body.dark .physton-prompt {
+   padding: 0;
+   margin: 0px 0 12px 0;
+   border-radius: var(--input-radius);
+   border-block-end-width: 1px;
+   border-top-left-radius: 0;
+   border-top-right-radius: 0;
+ }
+ body.dark .physton-prompt .prompt-header {
+   margin: 0;
+   border-bottom: 1px dashed #3741518c;
+   color:#bfc4c8;
+   padding-bottom: 0;
+ }
+/*设置hover*/
+body.dark .physton-prompt .prompt-header .prompt-header-extend .extend-content .extend-btn-group .extend-btn-item .setting-box {
+    top: -36px;
+    left: -10px;
+}
+/*翻译区块1*/
+body.dark .physton-prompt .prompt-tags {
+   background-color: #0d131c;
+   padding: 0;
+   display: flex;
+   flex-wrap: wrap;
+   justify-content: flex-start;
+   align-items: flex-start;
+   border-bottom-left-radius: 8px;
+   border-bottom-right-radius: 8px;
+ }
+/*翻译区块2*/
+body.dark .physton-prompt .prompt-tags .prompt-tags-list:empty {
+   margin: 0;
+   padding:0;
+   display: flex;
+   flex-wrap: wrap;
+   justify-content: flex-start;
+   align-items: flex-start;
+   width: 100%;
+ }
+body.dark .physton-prompt .prompt-tags .prompt-tags-list {
+   margin: 0;
+	padding: 8px;
+   display: flex;
+   flex-wrap: wrap;
+   justify-content: flex-start;
+   align-items: flex-start;
+   width: 100%;
+ }
+body.dark .physton-prompt .prompt-tags .prompt-tags-list .prompt-tag {
+    margin: 5px;
+    display: block;
+    align-items: center;
+    max-width: 100%;
+}
+
+
+body.dark .physton-prompt .prompt-tags .prompt-tags-list .prompt-tag .prompt-tag-main .prompt-tag-edit .prompt-tag-value {
+   width: calc(100% - 16px);
+   padding: 4px;
+   font-size: .9rem;
+   height: 24px;
+   border-radius: 4px;
+   border-top-right-radius: 0;
+   border-bottom-right-radius: 0;
+   display: flex;
+   align-items: center;
+   justify-content: flex-start;
+   color: var(--button-secondary-text-color);
+   background: #3741518c;
+   border: 0;
+ }
+body.dark .physton-prompt .prompt-tags .btn-tag-delete .icon-svg-close svg path {
+   fill: #4e5463;
+ }
+body.dark .physton-prompt .prompt-tags .prompt-tags-list .prompt-tag .prompt-tag-main .prompt-tag-edit .btn-tag-delete {
+   display: flex;
+   justify-content: center;
+   align-items: center;
+   cursor: pointer;
+   border: 0;
+   background: #2a324285;
+   padding: 0;
+   width: 16px;
+   height: 24px;
+   border-left: 1px solid #111824;
+   border-radius: 0;
+   border-top-right-radius: 4px;
+   border-bottom-right-radius: 4px;
+ }
+body.dark .physton-prompt .prompt-tags .prompt-tags-list .prompt-tag .prompt-tag-main .prompt-tag-edit .prompt-tag-value .character {
+   text-overflow: ellipsis;
+   overflow: hidden;
+   white-space: nowrap;
+   line-height: 1rem;
+   color: rgb(213 215 219);
+ }
+body.dark .physton-prompt .prompt-tags .prompt-local-language .icon-svg-translate svg path {
+   fill: #3a4554;
+ }
+body.dark #txt2img_prompt, body.dark #txt2img_neg_prompt, body.dark #img2img_prompt, body.dark #img2img_neg_prompt {
+   margin-bottom: -17px;
+ }
+body.dark input[type=text].svelte-1pie7s6, body.dark input[type=password].svelte-1pie7s6, body.dark input[type=email].svelte-1pie7s6, body.dark textarea.svelte-1pie7s6 {
+   display: block;
+   position: relative;
+   outline: none !important;
+   box-shadow: var(--input-shadow);
+   border: var(--input-border-width) solid var(--input-border-color);
+   border-radius: var(--input-radius);
+   border-bottom-left-radius: 0;
+   border-bottom-right-radius: 0;
+   background: var(--input-background-fill);
+   padding: var(--input-padding);
+   width: 100%;
+   color: var(--body-text-color);
+   font-weight: var(--input-text-weight);
+   font-size: var(--input-text-size);
+   line-height: var(--line-sm);
+ }
+body.dark .physton-prompt .prompt-tags .prompt-tags-list .prompt-tag .prompt-local-language .local-language {
+   font-size: .8rem;
+   color: #9ca3afc9;
+   margin-left: 2px;
+ }
+ /*隐藏原生框右上角的词组数量提示*/
+body.dark #txt2img_negative_token_counter, body.dark #txt2img_token_counter, body.dark #img2img_token_counter, body.dark #img2img_negative_token_counter {
+   position: absolute;
+   right: 1em;
+   min-width: 0 !important;
+   width: auto;
+   z-index: 100;
+   top: -0.75em;
+   display: none;
+ }
+
+ /*历史下拉弹窗*/
+body.dark .physton-prompt-favorite .popup-tab-content .content-list .content-item, body.dark .physton-prompt-history .popup-tab-content .content-list .content-item{
+padding: 6px 10px;
+    background-color: #181e2770;
+    border-radius: 4px;
+    margin: 5px;
+    border: 1px solid #303c4ba8;
+    cursor: pointer;
+}
+body.dark .physton-prompt-favorite .popup-tab-content .content-list .content-item:hover, body.dark .physton-prompt-history .popup-tab-content .content-list .content-item:hover{
+    background: rgb(115 139 199 / 20%);
+}
+body.dark .physton-prompt-favorite .popup-tab-content .content-list .content-item .item-prompt, body.dark .physton-prompt-history .popup-tab-content .content-list .content-item .item-prompt {
+    font-size: 12px;
+    color: #566073;
+}
+body.dark .physton-prompt-favorite .popup-tab-content .content-list .content-item:hover .item-prompt, body.dark .physton-prompt-history .popup-tab-content .content-list .content-item:hover .item-prompt {
+    overflow: visible;
+    white-space: normal;
+    font-size: 12px;
+    color: #eff3fa;
+}
+body.dark .physton-prompt-favorite .popup-tab-content .content-list .clear-btn, body.dark .physton-prompt-history .popup-tab-content .content-list .clear-btn {
+    background: rgb(40 50 64 / 94%);
+    border-radius: 5px;
+    margin:0;
+    position: sticky;
+    top: -1px;
+    padding: 10px 10px;
+    cursor: pointer;
+    border: 0;
+    color: #ff452d;
+    text-align: center;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+body.dark .physton-prompt-favorite .popup-tab-content .content-list .content-item .item-header .item-header-left .item-header-index, body.dark .physton-prompt-history .popup-tab-content .content-list .content-item .item-header .item-header-left .item-header-index {
+    background: #4a54ff;
+    padding: 2px 0;
+    width: 32px;
+    text-align: center;
+    border-radius: 4px;
+}
+body.dark .physton-prompt-favorite .popup-tab-content .content-list .content-item .item-header .item-header-left .item-header-name .header-name-input, body.dark .physton-prompt-history .popup-tab-content .content-list .content-item .item-header .item-header-left .item-header-name .header-name-input{
+    background: #0000004f;
+    border: 0;
+    border-radius: 3px;
+    height: 20px;
+    padding: 2px 4px;
+    width: 210px;
+    font-size: 12px;
+    color: #00F9E5;
+}
+body.dark .physton-prompt-favorite .popup-tabs .popup-tab, body.dark .physton-prompt-history .popup-tabs .popup-tab {
+    padding: 5px 0;
+    cursor: pointer;
+    position: relative;
+    flex: 1;
+    border-bottom: 0;
+}
+body.dark .physton-prompt .prompt-append-list {
+   width: auto;
+   height: auto;
+   padding: 6px;
+   margin: 0;
+   box-shadow: 0 0 6px 0 #4a54ff00;
+   backdrop-filter: blur(15px);
+   border-radius: 6px 6px 6px 6px;
+   transition: height .1s ease-in-out, width .1s ease-in-out;
+   color: #fff;
+   position: absolute;
+   z-index: 1000;
+   background: rgb(52 63 80 / 47%);
+ }
+body.dark .physton-prompt-favorite, body.dark .physton-prompt-history {
+   width: 500px;
+   height: auto;
+   padding: 6px;
+   margin: 0;
+   box-shadow: 0 0 6px 0 #4a54ff00;
+   backdrop-filter: blur(15px);
+   border-radius: 6px 6px 6px 6px;
+   background: rgb(53 62 76 / 53%);
+   transition: height .1s ease-in-out, width .1s ease-in-out;
+   color: #fff;
+   position: absolute;
+   z-index: 999;
+   top: 0;
+   left: 0;
+   overflow: visible;
+ }
+body.dark .physton-prompt .prompt-main.fold {
+    max-height: 42px
+}
+/*TAG上浮*/
+body.dark .physton-prompt .prompt-tags .prompt-tags-list .prompt-tag .prompt-tag-main:hover .btn-tag-extend, body.dark .physton-prompt .prompt-tags .prompt-tags-list .prompt-tag .prompt-tag-main:hover .prompt-tag-edit {
+  box-shadow: 0 0 0px 0 #4a54ff;;
+}

--- a/styles/extensions/lite-shuai/style.min.css
+++ b/styles/extensions/lite-shuai/style.min.css
@@ -1,71 +1,50 @@
- /*.physton-prompt .prompt-header .prompt-unfold .icon-svg-unfold:before {
-   
-    更换图标
-    Change icon
-    
-    background-image: url(/physton_prompt/styles?file=extensions/demo/images/test.png);
-    background-size: 100% 100%;
-    content: "";
-    display: inline-block;
-    width: 20px;
-    height: 20px
-}
-
-.physton-prompt .prompt-header .prompt-unfold .icon-svg-unfold svg {
-    /*
-    隐藏原始的图标
-    Hide the original icon
- 
- display: none }   */
- /*
-浅色主题
-Light theme
-*/
+/* 浅色主题  Light theme  */
  body.light .physton-prompt .prompt-header {
    /*
     更换标题栏背景色
     Change the background color of the title bar
     */
-   background: #
+   background: #000;
  }
- /**
-深色主题
-Dark theme
-*/
-body.dark ::-webkit-scrollbar {
-      width: 6px;
-      border-radius: 3px;
-  }
-body.dark ::-webkit-scrollbar-track {
-      background-color:#0d131c;
-      border-radius: 3px;
-  }
-body.dark ::-webkit-scrollbar-thumb {
-      background-color: #506c90;
-      border-radius: 3px;
-  }
+
+
+
+ /*  深色主题   Dark theme  */
+ body.dark ::-webkit-scrollbar {
+   width: 6px;
+   border-radius: 3px;
+ }
+ body.dark ::-webkit-scrollbar-track {
+   background-color: #0d131c;
+   border-radius: 3px;
+ }
+ body.dark ::-webkit-scrollbar-thumb {
+   background-color: #506c90;
+   border-radius: 3px;
+ }
  body.dark .physton-prompt .prompt-header {
    /*
     更换标题栏背景色
     Change the background color of the title bar
     */
-    margin: 0;
-    border-bottom: 1px dashed #3741518c;
-    color: #9ea7ae;
-	background-color: rgba(31, 41, 55, 0.56);
-	 height: 41px;
-	 padding-left: 8px;
-	 padding-right: 8px;
-	 padding-top: 2px;
+   margin: 0;
+   border-bottom: 1px dashed #3741518c;
+   color: #9ea7ae;
+   background-color: rgba(31, 41, 55, 0.56);
+   height: 41px;
+   padding-left: 8px;
+   padding-right: 8px;
+   padding-top: 2px;
  }
-/*图标颜色*/
- body.dark .physton-prompt .prompt-header .extend-btn-item .icon-svg-remove svg path,body.dark .physton-prompt .prompt-header .extend-btn-item .icon-svg-copy svg path,body.dark  .physton-prompt .prompt-header .extend-btn-item .icon-svg-english svg path,body.dark  .physton-prompt .prompt-header .extend-btn-item .icon-svg-translate svg path,body.dark .physton-prompt .prompt-header .extend-btn-item .icon-svg-favorite svg path,body.dark .physton-prompt .prompt-header .extend-btn-item .icon-svg-history svg path,body.dark .physton-prompt .prompt-header .extend-btn-item .icon-svg-setting svg path,body.dark .physton-prompt .prompt-header .extend-btn-item .icon-svg-i18n svg path,body.dark .physton-prompt .prompt-header .prompt-unfold .icon-svg-unfold svg path,body.dark .physton-prompt .prompt-header .icon-svg-input svg path {
+ /*图标颜色*/
+ body.dark .physton-prompt .prompt-header .extend-btn-item .icon-svg-remove svg path, body.dark .physton-prompt .prompt-header .extend-btn-item .icon-svg-copy svg path, body.dark .physton-prompt .prompt-header .extend-btn-item .icon-svg-english svg path, body.dark .physton-prompt .prompt-header .extend-btn-item .icon-svg-translate svg path, body.dark .physton-prompt .prompt-header .extend-btn-item .icon-svg-favorite svg path, body.dark .physton-prompt .prompt-header .extend-btn-item .icon-svg-history svg path, body.dark .physton-prompt .prompt-header .extend-btn-item .icon-svg-setting svg path, body.dark .physton-prompt .prompt-header .extend-btn-item .icon-svg-i18n svg path, body.dark .physton-prompt .prompt-header .prompt-unfold .icon-svg-unfold svg path, body.dark .physton-prompt .prompt-header .icon-svg-input svg path {
    fill: #596572;
  }
-
-/*图标尺寸*/
-body.dark .physton-prompt .prompt-header .setting-box .icon-svg-api svg,body.dark .physton-prompt .prompt-header .setting-box .icon-svg-theme svg,body.dark .physton-prompt .prompt-header .setting-box .icon-svg-remove-space svg,body.dark .physton-prompt .prompt-header .setting-box .icon-svg-tooltip svg{width: 18px;    height:18px;}
-
+ /*图标尺寸*/
+ body.dark .physton-prompt .prompt-header .setting-box .icon-svg-api svg, body.dark .physton-prompt .prompt-header .setting-box .icon-svg-theme svg, body.dark .physton-prompt .prompt-header .setting-box .icon-svg-remove-space svg, body.dark .physton-prompt .prompt-header .setting-box .icon-svg-tooltip svg {
+   width: 18px;
+   height: 18px;
+ }
  body.dark .physton-prompt .prompt-header .prompt-header-extend .extend-content .extend-btn-group {
    display: flex;
    justify-content: center;
@@ -76,8 +55,9 @@ body.dark .physton-prompt .prompt-header .setting-box .icon-svg-api svg,body.dar
    padding: 0;
    border-radius: 4px;
  }
-body.dark .physton-prompt .prompt-header .prompt-header-extend .extend-content .extend-btn-group .extend-btn-item:hover {
-   background:#b6c6d3;border-radius: 4px;
+ body.dark .physton-prompt .prompt-header .prompt-header-extend .extend-content .extend-btn-group .extend-btn-item:hover {
+   background: #b6c6d3;
+   border-radius: 4px;
  }
  body.dark .physton-prompt .prompt-header .prompt-header-extend .extend-content .extend-btn-group .extend-btn-item {
    cursor: pointer;
@@ -89,7 +69,7 @@ body.dark .physton-prompt .prompt-header .prompt-header-extend .extend-content .
    align-items: center;
    position: relative;
  }
-body.dark .physton-prompt .prompt-header .prompt-header-extend .extend-content .input-tag-append {
+ body.dark .physton-prompt .prompt-header .prompt-header-extend .extend-content .input-tag-append {
    display: block;
    position: relative;
    outline: none !important;
@@ -120,16 +100,16 @@ body.dark .physton-prompt .prompt-header .prompt-header-extend .extend-content .
  body.dark .physton-prompt .prompt-header {
    margin: 0;
    border-bottom: 1px dashed #3741518c;
-   color:#bfc4c8;
+   color: #bfc4c8;
    padding-bottom: 0;
  }
-/*设置hover*/
-body.dark .physton-prompt .prompt-header .prompt-header-extend .extend-content .extend-btn-group .extend-btn-item .setting-box {
-    top: -36px;
-    left: -10px;
-}
-/*翻译区块1*/
-body.dark .physton-prompt .prompt-tags {
+ /*设置hover*/
+ body.dark .physton-prompt .prompt-header .prompt-header-extend .extend-content .extend-btn-group .extend-btn-item .setting-box {
+   top: -36px;
+   left: -10px;
+ }
+ /*翻译区块1*/
+ body.dark .physton-prompt .prompt-tags {
    background-color: #0d131c;
    padding: 0;
    display: flex;
@@ -139,34 +119,32 @@ body.dark .physton-prompt .prompt-tags {
    border-bottom-left-radius: 8px;
    border-bottom-right-radius: 8px;
  }
-/*翻译区块2*/
-body.dark .physton-prompt .prompt-tags .prompt-tags-list:empty {
+ /*翻译区块2*/
+ body.dark .physton-prompt .prompt-tags .prompt-tags-list:empty {
    margin: 0;
-   padding:0;
+   padding: 0;
    display: flex;
    flex-wrap: wrap;
    justify-content: flex-start;
    align-items: flex-start;
    width: 100%;
  }
-body.dark .physton-prompt .prompt-tags .prompt-tags-list {
+ body.dark .physton-prompt .prompt-tags .prompt-tags-list {
    margin: 0;
-	padding: 8px;
+   padding: 8px;
    display: flex;
    flex-wrap: wrap;
    justify-content: flex-start;
    align-items: flex-start;
    width: 100%;
  }
-body.dark .physton-prompt .prompt-tags .prompt-tags-list .prompt-tag {
-    margin: 5px;
-    display: block;
-    align-items: center;
-    max-width: 100%;
-}
-
-
-body.dark .physton-prompt .prompt-tags .prompt-tags-list .prompt-tag .prompt-tag-main .prompt-tag-edit .prompt-tag-value {
+ body.dark .physton-prompt .prompt-tags .prompt-tags-list .prompt-tag {
+   margin: 5px;
+   display: block;
+   align-items: center;
+   max-width: 100%;
+ }
+ body.dark .physton-prompt .prompt-tags .prompt-tags-list .prompt-tag .prompt-tag-main .prompt-tag-edit .prompt-tag-value {
    width: calc(100% - 16px);
    padding: 4px;
    font-size: .9rem;
@@ -181,10 +159,10 @@ body.dark .physton-prompt .prompt-tags .prompt-tags-list .prompt-tag .prompt-tag
    background: #3741518c;
    border: 0;
  }
-body.dark .physton-prompt .prompt-tags .btn-tag-delete .icon-svg-close svg path {
+ body.dark .physton-prompt .prompt-tags .btn-tag-delete .icon-svg-close svg path {
    fill: #4e5463;
  }
-body.dark .physton-prompt .prompt-tags .prompt-tags-list .prompt-tag .prompt-tag-main .prompt-tag-edit .btn-tag-delete {
+ body.dark .physton-prompt .prompt-tags .prompt-tags-list .prompt-tag .prompt-tag-main .prompt-tag-edit .btn-tag-delete {
    display: flex;
    justify-content: center;
    align-items: center;
@@ -199,20 +177,20 @@ body.dark .physton-prompt .prompt-tags .prompt-tags-list .prompt-tag .prompt-tag
    border-top-right-radius: 4px;
    border-bottom-right-radius: 4px;
  }
-body.dark .physton-prompt .prompt-tags .prompt-tags-list .prompt-tag .prompt-tag-main .prompt-tag-edit .prompt-tag-value .character {
+ body.dark .physton-prompt .prompt-tags .prompt-tags-list .prompt-tag .prompt-tag-main .prompt-tag-edit .prompt-tag-value .character {
    text-overflow: ellipsis;
    overflow: hidden;
    white-space: nowrap;
    line-height: 1rem;
    color: rgb(213 215 219);
  }
-body.dark .physton-prompt .prompt-tags .prompt-local-language .icon-svg-translate svg path {
+ body.dark .physton-prompt .prompt-tags .prompt-local-language .icon-svg-translate svg path {
    fill: #3a4554;
  }
-body.dark #txt2img_prompt, body.dark #txt2img_neg_prompt, body.dark #img2img_prompt, body.dark #img2img_neg_prompt {
+ body.dark #txt2img_prompt, body.dark #txt2img_neg_prompt, body.dark #img2img_prompt, body.dark #img2img_neg_prompt {
    margin-bottom: -17px;
  }
-body.dark input[type=text].svelte-1pie7s6, body.dark input[type=password].svelte-1pie7s6, body.dark input[type=email].svelte-1pie7s6, body.dark textarea.svelte-1pie7s6 {
+ body.dark input[type=text].svelte-1pie7s6, body.dark input[type=password].svelte-1pie7s6, body.dark input[type=email].svelte-1pie7s6, body.dark textarea.svelte-1pie7s6 {
    display: block;
    position: relative;
    outline: none !important;
@@ -229,13 +207,13 @@ body.dark input[type=text].svelte-1pie7s6, body.dark input[type=password].svelte
    font-size: var(--input-text-size);
    line-height: var(--line-sm);
  }
-body.dark .physton-prompt .prompt-tags .prompt-tags-list .prompt-tag .prompt-local-language .local-language {
+ body.dark .physton-prompt .prompt-tags .prompt-tags-list .prompt-tag .prompt-local-language .local-language {
    font-size: .8rem;
    color: #9ca3afc9;
    margin-left: 2px;
  }
  /*隐藏原生框右上角的词组数量提示*/
-body.dark #txt2img_negative_token_counter, body.dark #txt2img_token_counter, body.dark #img2img_token_counter, body.dark #img2img_negative_token_counter {
+ body.dark #txt2img_negative_token_counter, body.dark #txt2img_token_counter, body.dark #img2img_token_counter, body.dark #img2img_negative_token_counter {
    position: absolute;
    right: 1em;
    min-width: 0 !important;
@@ -244,69 +222,68 @@ body.dark #txt2img_negative_token_counter, body.dark #txt2img_token_counter, bod
    top: -0.75em;
    display: none;
  }
-
  /*历史下拉弹窗*/
-body.dark .physton-prompt-favorite .popup-tab-content .content-list .content-item, body.dark .physton-prompt-history .popup-tab-content .content-list .content-item{
-padding: 6px 10px;
-    background-color: #181e2770;
-    border-radius: 4px;
-    margin: 5px;
-    border: 1px solid #303c4ba8;
-    cursor: pointer;
-}
-body.dark .physton-prompt-favorite .popup-tab-content .content-list .content-item:hover, body.dark .physton-prompt-history .popup-tab-content .content-list .content-item:hover{
-    background: rgb(115 139 199 / 20%);
-}
-body.dark .physton-prompt-favorite .popup-tab-content .content-list .content-item .item-prompt, body.dark .physton-prompt-history .popup-tab-content .content-list .content-item .item-prompt {
-    font-size: 12px;
-    color: #566073;
-}
-body.dark .physton-prompt-favorite .popup-tab-content .content-list .content-item:hover .item-prompt, body.dark .physton-prompt-history .popup-tab-content .content-list .content-item:hover .item-prompt {
-    overflow: visible;
-    white-space: normal;
-    font-size: 12px;
-    color: #eff3fa;
-}
-body.dark .physton-prompt-favorite .popup-tab-content .content-list .clear-btn, body.dark .physton-prompt-history .popup-tab-content .content-list .clear-btn {
-    background: rgb(40 50 64 / 94%);
-    border-radius: 5px;
-    margin:0;
-    position: sticky;
-    top: -1px;
-    padding: 10px 10px;
-    cursor: pointer;
-    border: 0;
-    color: #ff452d;
-    text-align: center;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-}
-body.dark .physton-prompt-favorite .popup-tab-content .content-list .content-item .item-header .item-header-left .item-header-index, body.dark .physton-prompt-history .popup-tab-content .content-list .content-item .item-header .item-header-left .item-header-index {
-    background: #4a54ff;
-    padding: 2px 0;
-    width: 32px;
-    text-align: center;
-    border-radius: 4px;
-}
-body.dark .physton-prompt-favorite .popup-tab-content .content-list .content-item .item-header .item-header-left .item-header-name .header-name-input, body.dark .physton-prompt-history .popup-tab-content .content-list .content-item .item-header .item-header-left .item-header-name .header-name-input{
-    background: #0000004f;
-    border: 0;
-    border-radius: 3px;
-    height: 20px;
-    padding: 2px 4px;
-    width: 210px;
-    font-size: 12px;
-    color: #00F9E5;
-}
-body.dark .physton-prompt-favorite .popup-tabs .popup-tab, body.dark .physton-prompt-history .popup-tabs .popup-tab {
-    padding: 5px 0;
-    cursor: pointer;
-    position: relative;
-    flex: 1;
-    border-bottom: 0;
-}
-body.dark .physton-prompt .prompt-append-list {
+ body.dark .physton-prompt-favorite .popup-tab-content .content-list .content-item, body.dark .physton-prompt-history .popup-tab-content .content-list .content-item {
+   padding: 6px 10px;
+   background-color: #181e2770;
+   border-radius: 4px;
+   margin: 5px;
+   border: 1px solid #303c4ba8;
+   cursor: pointer;
+ }
+ body.dark .physton-prompt-favorite .popup-tab-content .content-list .content-item:hover, body.dark .physton-prompt-history .popup-tab-content .content-list .content-item:hover {
+   background: rgb(115 139 199 / 20%);
+ }
+ body.dark .physton-prompt-favorite .popup-tab-content .content-list .content-item .item-prompt, body.dark .physton-prompt-history .popup-tab-content .content-list .content-item .item-prompt {
+   font-size: 12px;
+   color: #566073;
+ }
+ body.dark .physton-prompt-favorite .popup-tab-content .content-list .content-item:hover .item-prompt, body.dark .physton-prompt-history .popup-tab-content .content-list .content-item:hover .item-prompt {
+   overflow: visible;
+   white-space: normal;
+   font-size: 12px;
+   color: #eff3fa;
+ }
+ body.dark .physton-prompt-favorite .popup-tab-content .content-list .clear-btn, body.dark .physton-prompt-history .popup-tab-content .content-list .clear-btn {
+   background: rgb(40 50 64 / 94%);
+   border-radius: 5px;
+   margin: 0;
+   position: sticky;
+   top: -1px;
+   padding: 10px 10px;
+   cursor: pointer;
+   border: 0;
+   color: #ff452d;
+   text-align: center;
+   display: flex;
+   justify-content: center;
+   align-items: center;
+ }
+ body.dark .physton-prompt-favorite .popup-tab-content .content-list .content-item .item-header .item-header-left .item-header-index, body.dark .physton-prompt-history .popup-tab-content .content-list .content-item .item-header .item-header-left .item-header-index {
+   background: #4a54ff;
+   padding: 2px 0;
+   width: 32px;
+   text-align: center;
+   border-radius: 4px;
+ }
+ body.dark .physton-prompt-favorite .popup-tab-content .content-list .content-item .item-header .item-header-left .item-header-name .header-name-input, body.dark .physton-prompt-history .popup-tab-content .content-list .content-item .item-header .item-header-left .item-header-name .header-name-input {
+   background: #0000004f;
+   border: 0;
+   border-radius: 3px;
+   height: 20px;
+   padding: 2px 4px;
+   width: 210px;
+   font-size: 12px;
+   color: #00F9E5;
+ }
+ body.dark .physton-prompt-favorite .popup-tabs .popup-tab, body.dark .physton-prompt-history .popup-tabs .popup-tab {
+   padding: 5px 0;
+   cursor: pointer;
+   position: relative;
+   flex: 1;
+   border-bottom: 0;
+ }
+ body.dark .physton-prompt .prompt-append-list {
    width: auto;
    height: auto;
    padding: 6px;
@@ -320,7 +297,7 @@ body.dark .physton-prompt .prompt-append-list {
    z-index: 1000;
    background: rgb(52 63 80 / 47%);
  }
-body.dark .physton-prompt-favorite, body.dark .physton-prompt-history {
+ body.dark .physton-prompt-favorite, body.dark .physton-prompt-history {
    width: 500px;
    height: auto;
    padding: 6px;
@@ -337,10 +314,10 @@ body.dark .physton-prompt-favorite, body.dark .physton-prompt-history {
    left: 0;
    overflow: visible;
  }
-body.dark .physton-prompt .prompt-main.fold {
-    max-height: 42px
-}
-/*TAG上浮*/
-body.dark .physton-prompt .prompt-tags .prompt-tags-list .prompt-tag .prompt-tag-main:hover .btn-tag-extend, body.dark .physton-prompt .prompt-tags .prompt-tags-list .prompt-tag .prompt-tag-main:hover .prompt-tag-edit {
-  box-shadow: 0 0 0px 0 #4a54ff;;
-}
+ body.dark .physton-prompt .prompt-main.fold {
+   max-height: 42px
+ }
+ /*TAG上浮*/
+ body.dark .physton-prompt .prompt-tags .prompt-tags-list .prompt-tag .prompt-tag-main:hover .btn-tag-extend, body.dark .physton-prompt .prompt-tags .prompt-tags-list .prompt-tag .prompt-tag-main:hover .prompt-tag-edit {
+   box-shadow: 0 0 0px 0 #4a54ff;
+ }

--- a/styles/extensions/lite-shuai/style.min.css
+++ b/styles/extensions/lite-shuai/style.min.css
@@ -1,322 +1,311 @@
-/* 浅色主题  Light theme  */
- body.light .physton-prompt .prompt-header {
-   /*
+/*  深色主题   Dark theme  */
+body.dark ::-webkit-scrollbar {
+  width: 6px;
+  border-radius: 3px;
+}
+body.dark ::-webkit-scrollbar-track {
+  background-color: #0d131c;
+  border-radius: 3px;
+}
+body.dark ::-webkit-scrollbar-thumb {
+  background-color: #506c90;
+  border-radius: 3px;
+}
+body.dark .physton-prompt .prompt-header {
+  /*
     更换标题栏背景色
     Change the background color of the title bar
     */
-   background: #000;
- }
-
-
-
- /*  深色主题   Dark theme  */
- body.dark ::-webkit-scrollbar {
-   width: 6px;
-   border-radius: 3px;
- }
- body.dark ::-webkit-scrollbar-track {
-   background-color: #0d131c;
-   border-radius: 3px;
- }
- body.dark ::-webkit-scrollbar-thumb {
-   background-color: #506c90;
-   border-radius: 3px;
- }
- body.dark .physton-prompt .prompt-header {
-   /*
-    更换标题栏背景色
-    Change the background color of the title bar
-    */
-   margin: 0;
-   border-bottom: 1px dashed #3741518c;
-   color: #9ea7ae;
-   background-color: rgba(31, 41, 55, 0.56);
-   height: 41px;
-   padding-left: 8px;
-   padding-right: 8px;
-   padding-top: 2px;
- }
- /*图标颜色*/
- body.dark .physton-prompt .prompt-header .extend-btn-item .icon-svg-remove svg path, body.dark .physton-prompt .prompt-header .extend-btn-item .icon-svg-copy svg path, body.dark .physton-prompt .prompt-header .extend-btn-item .icon-svg-english svg path, body.dark .physton-prompt .prompt-header .extend-btn-item .icon-svg-translate svg path, body.dark .physton-prompt .prompt-header .extend-btn-item .icon-svg-favorite svg path, body.dark .physton-prompt .prompt-header .extend-btn-item .icon-svg-history svg path, body.dark .physton-prompt .prompt-header .extend-btn-item .icon-svg-setting svg path, body.dark .physton-prompt .prompt-header .extend-btn-item .icon-svg-i18n svg path, body.dark .physton-prompt .prompt-header .prompt-unfold .icon-svg-unfold svg path, body.dark .physton-prompt .prompt-header .icon-svg-input svg path {
-   fill: #596572;
- }
- /*图标尺寸*/
- body.dark .physton-prompt .prompt-header .setting-box .icon-svg-api svg, body.dark .physton-prompt .prompt-header .setting-box .icon-svg-theme svg, body.dark .physton-prompt .prompt-header .setting-box .icon-svg-remove-space svg, body.dark .physton-prompt .prompt-header .setting-box .icon-svg-tooltip svg {
-   width: 18px;
-   height: 18px;
- }
- body.dark .physton-prompt .prompt-header .prompt-header-extend .extend-content .extend-btn-group {
-   display: flex;
-   justify-content: center;
-   align-items: center;
-   color: #fff;
-   background: #0b0f19a6;
-   border: 0;
-   padding: 0;
-   border-radius: 4px;
- }
- body.dark .physton-prompt .prompt-header .prompt-header-extend .extend-content .extend-btn-group .extend-btn-item:hover {
-   background: #b6c6d3;
-   border-radius: 4px;
- }
- body.dark .physton-prompt .prompt-header .prompt-header-extend .extend-content .extend-btn-group .extend-btn-item {
-   cursor: pointer;
-   border-left: 1px solid #161e2a00;
-   height: 26px;
-   width: 30px;
-   display: flex;
-   justify-content: center;
-   align-items: center;
-   position: relative;
- }
- body.dark .physton-prompt .prompt-header .prompt-header-extend .extend-content .input-tag-append {
-   display: block;
-   position: relative;
-   outline: none !important;
-   height: 30px !important;
-   padding: 6px 8px !important;
-   box-shadow: var(--input-shadow);
-   border: var(--input-border-width) solid #232f41;
-   border-radius: var(--input-radius);
-   background: #0b0f19;
-   margin-left: 5px;
-   padding: var(--input-padding);
-   color: var(--body-text-color);
-   font-weight: var(--input-text-weight);
-   font-size: var(--input-text-size);
-   line-height: var(--line-sm);
- }
- body.dark .extend-content input::-webkit-input-placeholder {
-   color: #6b7280;
- }
- body.dark .physton-prompt {
-   padding: 0;
-   margin: 0px 0 12px 0;
-   border-radius: var(--input-radius);
-   border-block-end-width: 1px;
-   border-top-left-radius: 0;
-   border-top-right-radius: 0;
- }
- body.dark .physton-prompt .prompt-header {
-   margin: 0;
-   border-bottom: 1px dashed #3741518c;
-   color: #bfc4c8;
-   padding-bottom: 0;
- }
- /*设置hover*/
- body.dark .physton-prompt .prompt-header .prompt-header-extend .extend-content .extend-btn-group .extend-btn-item .setting-box {
-   top: -36px;
-   left: -10px;
- }
- /*翻译区块1*/
- body.dark .physton-prompt .prompt-tags {
-   background-color: #0d131c;
-   padding: 0;
-   display: flex;
-   flex-wrap: wrap;
-   justify-content: flex-start;
-   align-items: flex-start;
-   border-bottom-left-radius: 8px;
-   border-bottom-right-radius: 8px;
- }
- /*翻译区块2*/
- body.dark .physton-prompt .prompt-tags .prompt-tags-list:empty {
-   margin: 0;
-   padding: 0;
-   display: flex;
-   flex-wrap: wrap;
-   justify-content: flex-start;
-   align-items: flex-start;
-   width: 100%;
- }
- body.dark .physton-prompt .prompt-tags .prompt-tags-list {
-   margin: 0;
-   padding: 8px;
-   display: flex;
-   flex-wrap: wrap;
-   justify-content: flex-start;
-   align-items: flex-start;
-   width: 100%;
- }
- body.dark .physton-prompt .prompt-tags .prompt-tags-list .prompt-tag {
-   margin: 5px;
-   display: block;
-   align-items: center;
-   max-width: 100%;
- }
- body.dark .physton-prompt .prompt-tags .prompt-tags-list .prompt-tag .prompt-tag-main .prompt-tag-edit .prompt-tag-value {
-   width: calc(100% - 16px);
-   padding: 4px;
-   font-size: .9rem;
-   height: 24px;
-   border-radius: 4px;
-   border-top-right-radius: 0;
-   border-bottom-right-radius: 0;
-   display: flex;
-   align-items: center;
-   justify-content: flex-start;
-   color: var(--button-secondary-text-color);
-   background: #3741518c;
-   border: 0;
- }
- body.dark .physton-prompt .prompt-tags .btn-tag-delete .icon-svg-close svg path {
-   fill: #4e5463;
- }
- body.dark .physton-prompt .prompt-tags .prompt-tags-list .prompt-tag .prompt-tag-main .prompt-tag-edit .btn-tag-delete {
-   display: flex;
-   justify-content: center;
-   align-items: center;
-   cursor: pointer;
-   border: 0;
-   background: #2a324285;
-   padding: 0;
-   width: 16px;
-   height: 24px;
-   border-left: 1px solid #111824;
-   border-radius: 0;
-   border-top-right-radius: 4px;
-   border-bottom-right-radius: 4px;
- }
- body.dark .physton-prompt .prompt-tags .prompt-tags-list .prompt-tag .prompt-tag-main .prompt-tag-edit .prompt-tag-value .character {
-   text-overflow: ellipsis;
-   overflow: hidden;
-   line-height: 1rem;
-   color: rgb(213 215 219);
- }
- body.dark .physton-prompt .prompt-tags .prompt-local-language .icon-svg-translate svg path {
-   fill: #3a4554;
- }
- body.dark #txt2img_prompt, body.dark #txt2img_neg_prompt, body.dark #img2img_prompt, body.dark #img2img_neg_prompt {
-   margin-bottom: -17px;
- }
- body.dark input[type=text].svelte-1pie7s6, body.dark input[type=password].svelte-1pie7s6, body.dark input[type=email].svelte-1pie7s6, body.dark textarea.svelte-1pie7s6 {
-   display: block;
-   position: relative;
-   outline: none !important;
-   box-shadow: var(--input-shadow);
-   border: var(--input-border-width) solid var(--input-border-color);
-   border-radius: var(--input-radius);
-   border-bottom-left-radius: 0;
-   border-bottom-right-radius: 0;
-   background: var(--input-background-fill);
-   padding: var(--input-padding);
-   width: 100%;
-   color: var(--body-text-color);
-   font-weight: var(--input-text-weight);
-   font-size: var(--input-text-size);
-   line-height: var(--line-sm);
- }
- body.dark .physton-prompt .prompt-tags .prompt-tags-list .prompt-tag .prompt-local-language .local-language {
-   font-size: .8rem;
-   color: #9ca3afc9;
-   margin-left: 2px;
- }
- /*隐藏原生框右上角的词组数量提示*/
- body.dark #txt2img_negative_token_counter, body.dark #txt2img_token_counter, body.dark #img2img_token_counter, body.dark #img2img_negative_token_counter {
-   position: absolute;
-   right: 1em;
-   min-width: 0 !important;
-   width: auto;
-   z-index: 100;
-   top: -0.75em;
-   display: none;
- }
- /*历史下拉弹窗*/
- body.dark .physton-prompt-favorite .popup-tab-content .content-list .content-item, body.dark .physton-prompt-history .popup-tab-content .content-list .content-item {
-   padding: 6px 10px;
-   background-color: #181e2770;
-   border-radius: 4px;
-   margin: 5px;
-   border: 1px solid #303c4ba8;
-   cursor: pointer;
- }
- body.dark .physton-prompt-favorite .popup-tab-content .content-list .content-item:hover, body.dark .physton-prompt-history .popup-tab-content .content-list .content-item:hover {
-   background: rgb(115 139 199 / 20%);
- }
- body.dark .physton-prompt-favorite .popup-tab-content .content-list .content-item .item-prompt, body.dark .physton-prompt-history .popup-tab-content .content-list .content-item .item-prompt {
-   font-size: 12px;
-   color: #566073;
- }
- body.dark .physton-prompt-favorite .popup-tab-content .content-list .content-item:hover .item-prompt, body.dark .physton-prompt-history .popup-tab-content .content-list .content-item:hover .item-prompt {
-   overflow: visible;
-   white-space: normal;
-   font-size: 12px;
-   color: #eff3fa;
- }
- body.dark .physton-prompt-favorite .popup-tab-content .content-list .clear-btn, body.dark .physton-prompt-history .popup-tab-content .content-list .clear-btn {
-   background: rgb(40 50 64 / 94%);
-   border-radius: 5px;
-   margin: 0;
-   position: sticky;
-   top: -1px;
-   padding: 10px 10px;
-   cursor: pointer;
-   border: 0;
-   color: #ff452d;
-   text-align: center;
-   display: flex;
-   justify-content: center;
-   align-items: center;
- }
- body.dark .physton-prompt-favorite .popup-tab-content .content-list .content-item .item-header .item-header-left .item-header-index, body.dark .physton-prompt-history .popup-tab-content .content-list .content-item .item-header .item-header-left .item-header-index {
-   background: #4a54ff;
-   padding: 2px 0;
-   width: 32px;
-   text-align: center;
-   border-radius: 4px;
- }
- body.dark .physton-prompt-favorite .popup-tab-content .content-list .content-item .item-header .item-header-left .item-header-name .header-name-input, body.dark .physton-prompt-history .popup-tab-content .content-list .content-item .item-header .item-header-left .item-header-name .header-name-input {
-   background: #0000004f;
-   border: 0;
-   border-radius: 3px;
-   height: 20px;
-   padding: 2px 4px;
-   width: 210px;
-   font-size: 12px;
-   color: #00F9E5;
- }
- body.dark .physton-prompt-favorite .popup-tabs .popup-tab, body.dark .physton-prompt-history .popup-tabs .popup-tab {
-   padding: 5px 0;
-   cursor: pointer;
-   position: relative;
-   flex: 1;
-   border-bottom: 0;
- }
- body.dark .physton-prompt .prompt-append-list {
-   width: auto;
-   height: auto;
-   padding: 6px;
-   margin: 0;
-   box-shadow: 0 0 6px 0 #4a54ff00;
-   backdrop-filter: blur(15px);
-   border-radius: 6px 6px 6px 6px;
-   transition: height .1s ease-in-out, width .1s ease-in-out;
-   color: #fff;
-   position: absolute;
-   z-index: 1000;
-   background: rgb(52 63 80 / 47%);
- }
- body.dark .physton-prompt-favorite, body.dark .physton-prompt-history {
-   width: 500px;
-   height: auto;
-   padding: 6px;
-   margin: 0;
-   box-shadow: 0 0 6px 0 #4a54ff00;
-   backdrop-filter: blur(15px);
-   border-radius: 6px 6px 6px 6px;
-   background: rgb(53 62 76 / 53%);
-   transition: height .1s ease-in-out, width .1s ease-in-out;
-   color: #fff;
-   position: absolute;
-   z-index: 999;
-   top: 0;
-   left: 0;
-   overflow: visible;
- }
- body.dark .physton-prompt .prompt-main.fold {
-   max-height: 42px
- }
- /*TAG上浮*/
- body.dark .physton-prompt .prompt-tags .prompt-tags-list .prompt-tag .prompt-tag-main:hover .btn-tag-extend, body.dark .physton-prompt .prompt-tags .prompt-tags-list .prompt-tag .prompt-tag-main:hover .prompt-tag-edit {
-   box-shadow: 0 0 0px 0 #4a54ff;
- }
+  margin: 0;
+  border-bottom: 1px dashed #3741518c;
+  color: #9ea7ae;
+  background-color: rgba(31, 41, 55, 0.56);
+  height: 41px;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 2px;
+}
+/*图标颜色*/
+body.dark .physton-prompt .prompt-header .extend-btn-item .icon-svg-remove svg path, body.dark .physton-prompt .prompt-header .extend-btn-item .icon-svg-copy svg path, body.dark .physton-prompt .prompt-header .extend-btn-item .icon-svg-english svg path, body.dark .physton-prompt .prompt-header .extend-btn-item .icon-svg-translate svg path, body.dark .physton-prompt .prompt-header .extend-btn-item .icon-svg-favorite svg path, body.dark .physton-prompt .prompt-header .extend-btn-item .icon-svg-history svg path, body.dark .physton-prompt .prompt-header .extend-btn-item .icon-svg-setting svg path, body.dark .physton-prompt .prompt-header .extend-btn-item .icon-svg-i18n svg path, body.dark .physton-prompt .prompt-header .prompt-unfold .icon-svg-unfold svg path, body.dark .physton-prompt .prompt-header .icon-svg-input svg path {
+  fill: #596572;
+}
+/*图标尺寸*/
+body.dark .physton-prompt .prompt-header .setting-box .icon-svg-api svg, body.dark .physton-prompt .prompt-header .setting-box .icon-svg-theme svg, body.dark .physton-prompt .prompt-header .setting-box .icon-svg-remove-space svg, body.dark .physton-prompt .prompt-header .setting-box .icon-svg-tooltip svg {
+  width: 18px;
+  height: 18px;
+}
+body.dark .physton-prompt .prompt-header .prompt-header-extend .extend-content .extend-btn-group {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: #fff;
+  background: #0b0f19a6;
+  border: 0;
+  padding: 0;
+  border-radius: 4px;
+}
+body.dark .physton-prompt .prompt-header .prompt-header-extend .extend-content .extend-btn-group .extend-btn-item:hover {
+  background: #b6c6d3;
+  border-radius: 4px;
+}
+body.dark .physton-prompt .prompt-header .prompt-header-extend .extend-content .extend-btn-group .extend-btn-item {
+  cursor: pointer;
+  border-left: 1px solid #161e2a00;
+  height: 26px;
+  width: 30px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+}
+body.dark .physton-prompt .prompt-header .prompt-header-extend .extend-content .input-tag-append {
+  display: block;
+  position: relative;
+  outline: none !important;
+  height: 30px !important;
+  padding: 6px 8px !important;
+  box-shadow: var(--input-shadow);
+  border: var(--input-border-width) solid #232f41;
+  border-radius: var(--input-radius);
+  background: #0b0f19;
+  margin-left: 5px;
+  padding: var(--input-padding);
+  color: var(--body-text-color);
+  font-weight: var(--input-text-weight);
+  font-size: var(--input-text-size);
+  line-height: var(--line-sm);
+}
+body.dark .extend-content input::-webkit-input-placeholder {
+  color: #6b7280;
+}
+body.dark .physton-prompt {
+  padding: 0;
+  margin: 0px 0 12px 0;
+  border-radius: var(--input-radius);
+  border-block-end-width: 1px;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+body.dark .physton-prompt .prompt-header {
+  margin: 0;
+  border-bottom: 1px dashed #3741518c;
+  color: #bfc4c8;
+  padding-bottom: 0;
+}
+/*设置hover*/
+body.dark .physton-prompt .prompt-header .prompt-header-extend .extend-content .extend-btn-group .extend-btn-item .setting-box {
+  top: -36px;
+  left: -10px;
+}
+/*翻译区块1*/
+body.dark .physton-prompt .prompt-tags {
+  background-color: #0d131c;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  align-items: flex-start;
+  border-bottom-left-radius: 8px;
+  border-bottom-right-radius: 8px;
+}
+/*翻译区块2*/
+body.dark .physton-prompt .prompt-tags .prompt-tags-list:empty {
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  align-items: flex-start;
+  width: 100%;
+}
+body.dark .physton-prompt .prompt-tags .prompt-tags-list {
+  margin: 0;
+  padding: 8px;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  align-items: flex-start;
+  width: 100%;
+}
+body.dark .physton-prompt .prompt-tags .prompt-tags-list .prompt-tag {
+  margin: 5px;
+  display: block;
+  align-items: center;
+  max-width: 100%;
+}
+body.dark .physton-prompt .prompt-tags .prompt-tags-list .prompt-tag .prompt-tag-main .prompt-tag-edit .prompt-tag-value {
+  width: calc(100% - 16px);
+  padding: 4px;
+  font-size: .9rem;
+  height: 24px;
+  border-radius: 4px;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  color: var(--button-secondary-text-color);
+  background: #3741518c;
+  border: 0;
+}
+body.dark .physton-prompt .prompt-tags .btn-tag-delete .icon-svg-close svg path {
+  fill: #4e5463;
+}
+body.dark .physton-prompt .prompt-tags .prompt-tags-list .prompt-tag .prompt-tag-main .prompt-tag-edit .btn-tag-delete {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+  border: 0;
+  background: #2a324285;
+  padding: 0;
+  width: 16px;
+  height: 24px;
+  border-left: 1px solid #111824;
+  border-radius: 0;
+  border-top-right-radius: 4px;
+  border-bottom-right-radius: 4px;
+}
+body.dark .physton-prompt .prompt-tags .prompt-tags-list .prompt-tag .prompt-tag-main .prompt-tag-edit .prompt-tag-value .character {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  line-height: 1rem;
+  color: rgb(213 215 219);
+}
+body.dark .physton-prompt .prompt-tags .prompt-local-language .icon-svg-translate svg path {
+  fill: #3a4554;
+}
+body.dark #txt2img_prompt, body.dark #txt2img_neg_prompt, body.dark #img2img_prompt, body.dark #img2img_neg_prompt {
+  margin-bottom: -17px;
+}
+body.dark input[type=text].svelte-1pie7s6, body.dark input[type=password].svelte-1pie7s6, body.dark input[type=email].svelte-1pie7s6, body.dark textarea.svelte-1pie7s6 {
+  display: block;
+  position: relative;
+  outline: none !important;
+  box-shadow: var(--input-shadow);
+  border: var(--input-border-width) solid var(--input-border-color);
+  border-radius: var(--input-radius);
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  background: var(--input-background-fill);
+  padding: var(--input-padding);
+  width: 100%;
+  color: var(--body-text-color);
+  font-weight: var(--input-text-weight);
+  font-size: var(--input-text-size);
+  line-height: var(--line-sm);
+}
+body.dark .physton-prompt .prompt-tags .prompt-tags-list .prompt-tag .prompt-local-language .local-language {
+  font-size: .8rem;
+  color: #9ca3afc9;
+  margin-left: 2px;
+}
+/*隐藏原生框右上角的词组数量提示*/
+body.dark #txt2img_negative_token_counter, body.dark #txt2img_token_counter, body.dark #img2img_token_counter, body.dark #img2img_negative_token_counter {
+  position: absolute;
+  right: 1em;
+  min-width: 0 !important;
+  width: auto;
+  z-index: 100;
+  top: -0.75em;
+  display: none;
+}
+/*历史下拉弹窗*/
+body.dark .physton-prompt-favorite .popup-tab-content .content-list .content-item, body.dark .physton-prompt-history .popup-tab-content .content-list .content-item {
+  padding: 6px 10px;
+  background-color: #181e2770;
+  border-radius: 4px;
+  margin: 5px;
+  border: 1px solid #303c4ba8;
+  cursor: pointer;
+}
+body.dark .physton-prompt-favorite .popup-tab-content .content-list .content-item:hover, body.dark .physton-prompt-history .popup-tab-content .content-list .content-item:hover {
+  background: rgb(115 139 199 / 20%);
+}
+body.dark .physton-prompt-favorite .popup-tab-content .content-list .content-item .item-prompt, body.dark .physton-prompt-history .popup-tab-content .content-list .content-item .item-prompt {
+  font-size: 12px;
+  color: #566073;
+}
+body.dark .physton-prompt-favorite .popup-tab-content .content-list .content-item:hover .item-prompt, body.dark .physton-prompt-history .popup-tab-content .content-list .content-item:hover .item-prompt {
+  overflow: visible;
+  white-space: normal;
+  font-size: 12px;
+  color: #eff3fa;
+}
+body.dark .physton-prompt-favorite .popup-tab-content .content-list .clear-btn, body.dark .physton-prompt-history .popup-tab-content .content-list .clear-btn {
+  background: rgb(40 50 64 / 94%);
+  border-radius: 5px;
+  margin: 0;
+  position: sticky;
+  top: -1px;
+  padding: 10px 10px;
+  cursor: pointer;
+  border: 0;
+  color: #ff452d;
+  text-align: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+body.dark .physton-prompt-favorite .popup-tab-content .content-list .content-item .item-header .item-header-left .item-header-index, body.dark .physton-prompt-history .popup-tab-content .content-list .content-item .item-header .item-header-left .item-header-index {
+  background: #4a54ff;
+  padding: 2px 0;
+  width: 32px;
+  text-align: center;
+  border-radius: 4px;
+}
+body.dark .physton-prompt-favorite .popup-tab-content .content-list .content-item .item-header .item-header-left .item-header-name .header-name-input, body.dark .physton-prompt-history .popup-tab-content .content-list .content-item .item-header .item-header-left .item-header-name .header-name-input {
+  background: #0000004f;
+  border: 0;
+  border-radius: 3px;
+  height: 20px;
+  padding: 2px 4px;
+  width: 210px;
+  font-size: 12px;
+  color: #00F9E5;
+}
+body.dark .physton-prompt-favorite .popup-tabs .popup-tab, body.dark .physton-prompt-history .popup-tabs .popup-tab {
+  padding: 5px 0;
+  cursor: pointer;
+  position: relative;
+  flex: 1;
+  border-bottom: 0;
+}
+body.dark .physton-prompt .prompt-append-list {
+  width: auto;
+  height: auto;
+  padding: 6px;
+  margin: 0;
+  box-shadow: 0 0 6px 0 #4a54ff00;
+  backdrop-filter: blur(15px);
+  border-radius: 6px 6px 6px 6px;
+  transition: height .1s ease-in-out, width .1s ease-in-out;
+  color: #fff;
+  position: absolute;
+  z-index: 1000;
+  background: rgb(52 63 80 / 47%);
+}
+body.dark .physton-prompt-favorite, body.dark .physton-prompt-history {
+  width: 500px;
+  height: auto;
+  padding: 6px;
+  margin: 0;
+  box-shadow: 0 0 6px 0 #4a54ff00;
+  backdrop-filter: blur(15px);
+  border-radius: 6px 6px 6px 6px;
+  background: rgb(53 62 76 / 53%);
+  transition: height .1s ease-in-out, width .1s ease-in-out;
+  color: #fff;
+  position: absolute;
+  z-index: 999;
+  top: 0;
+  left: 0;
+  overflow: visible;
+}
+body.dark .physton-prompt .prompt-main.fold {
+  max-height: 42px
+}
+/*TAG上浮*/
+body.dark .physton-prompt .prompt-tags .prompt-tags-list .prompt-tag .prompt-tag-main:hover .btn-tag-extend, body.dark .physton-prompt .prompt-tags .prompt-tags-list .prompt-tag .prompt-tag-main:hover .prompt-tag-edit {
+  box-shadow: 0 0 0px 0 #4a54ff;
+}

--- a/styles/extensions/lite-shuai/style.min.css
+++ b/styles/extensions/lite-shuai/style.min.css
@@ -180,7 +180,6 @@
  body.dark .physton-prompt .prompt-tags .prompt-tags-list .prompt-tag .prompt-tag-main .prompt-tag-edit .prompt-tag-value .character {
    text-overflow: ellipsis;
    overflow: hidden;
-   white-space: nowrap;
    line-height: 1rem;
    color: rgb(213 215 219);
  }


### PR DESCRIPTION
插件很好用，所以调整了让自己觉得舒适的界面。
主界面和webUI自带的tag框相融合，让这个插件能更好的在webUI里出现，而不显得突兀，满满原生感。
目前初版，暂时只适配了暗色皮肤，edge、chrome、火狐测试了，IE没测试。
主界面基本完工，只调成了CSS部分，没改动其他文件，一些弹窗还待后续调整。

另外发现css 里用  body.light  前缀测试浅色模式好像没效果？不知道是不是我哪搞错了。

界面对比
![dsadas](https://github.com/Physton/sd-webui-prompt-all-in-one/assets/32892476/eefd74cc-f5c0-450d-88b3-505ca56441d7)

默认界面
<img width="1920" alt="1" src="https://github.com/Physton/sd-webui-prompt-all-in-one/assets/32892476/1f9d795e-b4a3-4d52-bcd7-b8de3b81919a">

有tag后的界面
<img width="1920" alt="2" src="https://github.com/Physton/sd-webui-prompt-all-in-one/assets/32892476/e13ef708-c1d8-4774-b6fa-a5eefe4da247">

有tag，隐藏原生输入框后的界面
<img width="1920" alt="3" src="https://github.com/Physton/sd-webui-prompt-all-in-one/assets/32892476/acbba8be-e946-4a14-83e8-c0f279f802ba">

弹窗，后续会再调整
<img width="1920" alt="5" src="https://github.com/Physton/sd-webui-prompt-all-in-one/assets/32892476/0c73474b-9712-4c65-b2c4-7341b7838424">

<img width="1920" alt="4" src="https://github.com/Physton/sd-webui-prompt-all-in-one/assets/32892476/74ab2e53-5251-4c3f-ad96-50c2e49c4fc8">
