### PR TITLE
FIX: Token Counter TypeError (v2: Handle cond_stage_model is None)

### DIFF
--- a/scripts/physton_prompt/get_token_counter.py
+++ b/scripts/physton_prompt/get_token_counter.py
@@ -4,8 +4,10 @@ from functools import partial, reduce
 
 
 def get_token_counter(text, steps):
-    # Check if the model is fully loaded to prevent TypeError during model switching
-    if sd_models.model_data.sd_model is None:
+    # Check if the model is fully loaded to prevent TypeError during model switching.
+    # Checks both sd_model and its subcomponent (cond_stage_model).
+    if sd_models.model_data.sd_model is None or \
+       sd_models.model_data.sd_model.cond_stage_model is None:
         return {"token_count": 0, "max_length": 0}
 
     # copy from modules.ui.py


### PR DESCRIPTION
This fix addresses the TypeError in the token counter that occurs during model swapping operations (e.g., XYZ Plot).
It ensures that the required model components are present before token counting begins.
See commit for details.