### PR TITLE
Fix: Use try-except to stabilize token counter during model access

### DIFF
--- a/scripts/physton_prompt/get_token_counter.py
+++ b/scripts/physton_prompt/get_token_counter.py
@@ -4,39 +4,41 @@ from functools import partial, reduce
 
 
 def get_token_counter(text, steps):
-    # FIX: Robust Null Check to prevent TypeError during model loading/unloading.
-    # Checks for the existence of model_data and its property sd_model sequentially.
-    if sd_models.model_data is None or sd_models.model_data.sd_model is None:
+    # FIX: Use try-except to safely handle PyTorch/model access errors (TypeError NoneType)
+    # that occur during model loading/switching when the token counter API is triggered.
+    try:
+        # copy from modules.ui.py
+        try:
+            text, _ = extra_networks.parse_prompt(text)
+
+            _, prompt_flat_list, _ = prompt_parser.get_multicond_prompt_list([text])
+            prompt_schedules = prompt_parser.get_learned_conditioning_prompt_schedules(prompt_flat_list, steps)
+
+        except Exception:
+            # a parsing error can happen here during typing, and we don't want to bother the user with
+            # messages related to it in console
+            prompt_schedules = [[[steps, text]]]
+
+        try:
+            from modules_forge import forge_version
+            forge = True
+
+        except:
+            forge = False
+
+        flat_prompts = reduce(lambda list1, list2: list1 + list2, prompt_schedules)
+        prompts = [prompt_text for step, prompt_text in flat_prompts]
+
+        if forge:
+            cond_stage_model = sd_models.model_data.sd_model.cond_stage_model
+            token_count, max_length = max([model_hijack.get_prompt_lengths(prompt,cond_stage_model) for prompt in prompts],
+                                        key=lambda args: args[0])
+        else:
+            token_count, max_length = max([model_hijack.get_prompt_lengths(prompt) for prompt in prompts],
+                                        key=lambda args: args[0])
+
+        return {"token_count": token_count, "max_length": max_length}
+
+    except Exception as e:
+        # return 0 token count if any error (model instability, parsing error, etc.) occurs during calculation
         return {"token_count": 0, "max_length": 0}
-
-    # copy from modules.ui.py
-    try:
-        text, _ = extra_networks.parse_prompt(text)
-
-        _, prompt_flat_list, _ = prompt_parser.get_multicond_prompt_list([text])
-        prompt_schedules = prompt_parser.get_learned_conditioning_prompt_schedules(prompt_flat_list, steps)
-
-    except Exception:
-        # a parsing error can happen here during typing, and we don't want to bother the user with
-        # messages related to it in console
-        prompt_schedules = [[[steps, text]]]
-
-    try:
-        from modules_forge import forge_version
-        forge = True
-
-    except:
-        forge = False
-
-    flat_prompts = reduce(lambda list1, list2: list1 + list2, prompt_schedules)
-    prompts = [prompt_text for step, prompt_text in flat_prompts]
-
-    if forge:
-        cond_stage_model = sd_models.model_data.sd_model.cond_stage_model
-        token_count, max_length = max([model_hijack.get_prompt_lengths(prompt,cond_stage_model) for prompt in prompts],
-                                      key=lambda args: args[0])
-    else:
-        token_count, max_length = max([model_hijack.get_prompt_lengths(prompt) for prompt in prompts],
-                                      key=lambda args: args[0])
-
-    return {"token_count": token_count, "max_length": max_length}

--- a/scripts/physton_prompt/get_token_counter.py
+++ b/scripts/physton_prompt/get_token_counter.py
@@ -4,10 +4,9 @@ from functools import partial, reduce
 
 
 def get_token_counter(text, steps):
-    # Check if the model is fully loaded to prevent TypeError during model switching.
-    # Checks both sd_model and its subcomponent (cond_stage_model).
-    if sd_models.model_data.sd_model is None or \
-       sd_models.model_data.sd_model.cond_stage_model is None:
+    # FIX: Robust Null Check to prevent TypeError during model loading/unloading.
+    # Checks for the existence of model_data and its property sd_model sequentially.
+    if sd_models.model_data is None or sd_models.model_data.sd_model is None:
         return {"token_count": 0, "max_length": 0}
 
     # copy from modules.ui.py


### PR DESCRIPTION
This commit fixes a critical server crash issue that occurs when the token counter API is triggered during model instability.

## 🐛 Bug Details

The crash occurs when the token counter API is called (e.g., by user interaction like using a word/tag completion extension) while the model is switching or loading (e.g., via the dropdown menu or XYZ Plot).

* **Cause:** The model object (`sd_models.model_data.sd_model`) exists in memory but its internal component, `cond_stage_model`, is momentarily `None` or in an incomplete state due to aggressive memory management in Forge/reForge.
* **Crash Location:** Accessing the `.cond_stage_model` attribute triggers a `TypeError: argument of type 'NoneType' is not iterable` within PyTorch's internal `__getattr__` method, which standard Python `if` checks cannot safely bypass.

## 🛠️ Solution and Rationale

Previous attempts using sequential `if` checks (e.g., `if A is None or A.B is None`) failed because the crash happened inside PyTorch's attribute lookup process, bypassing Python's short-circuit evaluation.

* **Solution:** The entire critical section of the `get_token_counter` function is wrapped in a **`try-except`** block as the final and most robust defense.
* **Action:** If a model access error occurs due to instability, the function safely returns `{"token_count": 0, "max_length": 0}` instead of crashing the server.

## 🕹️ Reproduction Steps

1.  Start a model load/switch (e.g., selecting a different model from the top-left dropdown).
2.  While the model is loading (monitor "Loading model..." in logs), **actively change the prompt content** (e.g., using a word/tag completion extension's add/remove button) to repeatedly trigger the token counter API.
3.  Server crashes immediately.